### PR TITLE
Add a new commandline option for overriding the browser instance of choice.

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const { getRootUrlFromEnv, parseNonSpaceSeparatedList } = require( './lib/misc.j
 // TODO: this shouldn't be too hard to generalized to enable complete overriding of config flags through commandline params. I should consider to implement a config schema.
 const parseOverrides = ( argv ) => {
 	const eligibleParams = [
+		'browser',
 		'cookies',
 		'env',
 		'path',
@@ -47,6 +48,10 @@ const parseCommandLine = () => {
 	const argv = yargs
 		.option( 'action-files', {
 			alias: 'A',
+			type: 'string',
+		} )
+		.option( 'browser', {
+			alias: 'B',
 			type: 'string',
 		} )
 		.option( 'config-files', {


### PR DESCRIPTION
## Description

Add a `--browser, -B` commandline parameter for overriding the type of browser instance of choice.

## Test plan

See if `yarn start -B firefox` can override the default chromium.