### PR TITLE
Enhance `close-account` action to handle more cases.

### DIFF
--- a/actions/close-account.js
+++ b/actions/close-account.js
@@ -16,11 +16,13 @@ module.exports = createAction(
 
 		await page.goto( getRootUrlFromEnv( extra.config.env ) + '/me/account/close' );
 
-		// this isn't perfect, but works for me :(
-		await page.waitForTimeout( 1000 );
+		// waiting for the placeholder to be gone
+		await page.waitForSelector( 'div.account-close.is-loading', {
+			state: 'hidden',
+		} );
 
 		// click the Close Account button
-		await page.click( 'css=div.action-panel >> css=button.is-scary' );
+		await page.click( 'css=div.action-panel__cta >> css=button.is-scary' );
 
 		// click the Continue button on the survey screen
 		await page.click( 'css=div.dialog__action-buttons >> css=button.is-primary' );
@@ -30,6 +32,9 @@ module.exports = createAction(
 
 		// final doom
 		await page.click( 'css=div.dialog__action-buttons >> css=button.is-scary' );
+
+		// waiting for the final screen
+		await page.waitForSelector( 'css=div.empty-content' );
 
 		return {
 			done: true,

--- a/actions/close-account.js
+++ b/actions/close-account.js
@@ -1,4 +1,4 @@
-const { createAction, readAction } = require( '../lib/action.js' );
+const { createAction, readActionFile } = require( '../lib/action.js' );
 const { getRootUrlFromEnv } = require( '../lib/misc.js' );
 
 const closeAccount = createAction(
@@ -26,7 +26,14 @@ const closeAccount = createAction(
 		} );
 
 		if ( managePurchaseButton ) {
-			const removePurchaseAction = readAction( 'remove-purchases' );
+			const removePurchaseAction = readActionFile( 'remove-purchase' );
+
+			if ( ! removePurchaseAction ) {
+				console.error( 'Cannot find remove-purch' );
+				return {
+					abort: true,
+				};
+			}
 
 			await removePurchaseAction.run( browser, context, page, extra );
 

--- a/actions/close-account.js
+++ b/actions/close-account.js
@@ -20,16 +20,16 @@ const closeAccount = createAction(
 			state: 'hidden',
 		} );
 
-		// if this is not null, it means that this account has pending effective purchases to remove.
-		const managePurchaseButton = await page.waitForSelector( 'css=a[href="/me/purchases"]', {
-			timeout: 1000,
-		} );
+		try {
+			// if this button has presented, it means that this account has pending effective purchases to remove.
+			await page.waitForSelector( 'css=div.account-close a[href="/me/purchases"]', {
+				timeout: 1000,
+			} );
 
-		if ( managePurchaseButton ) {
-			const removePurchaseAction = readActionFile( 'remove-purchase' );
+			const removePurchaseAction = readActionFile( 'remove-all-purchases' );
 
 			if ( ! removePurchaseAction ) {
-				console.error( 'Cannot find remove-purch' );
+				console.error( 'Cannot find the action for removing all the purchases. Aborting.' );
 				return {
 					abort: true,
 				};
@@ -38,6 +38,8 @@ const closeAccount = createAction(
 			await removePurchaseAction.run( browser, context, page, extra );
 
 			return await closeAccount.run( browser, context, page, extra );
+		} catch {
+			console.log( '---------No remaing purchases. The account is ready to be closed.' );
 		}
 
 		// click the Close Account button

--- a/actions/remove-all-purchases.js
+++ b/actions/remove-all-purchases.js
@@ -6,7 +6,7 @@ const validator = require( 'validator' );
 /**
  * Internal dependencies
  */
-const { createAction } = require( '../lib/action.js' );
+const { asyncIf, createAction } = require( '../lib/action.js' );
 const { getRootUrlFromEnv } = require( '../lib/misc.js' );
 
 const extractDomainStringfromDialog = async ( page ) => {
@@ -30,88 +30,80 @@ const removePurchase = createAction(
 		await page.click( 'css=a[data-e2e-connected-site=true]:last-child' );
 
 		// Toggle off auto-renewal if any
-		try {
-			await page.click( 'css=.components-form-toggle.is-checked input[type="checkbox"]', {
+		await asyncIf(
+			async () => page.click( 'css=.components-form-toggle.is-checked input[type="checkbox"]', {
 				timeout: 1000,
-			} );
+			} ),
+			async () => {
+				await page.click( 'div.auto-renew-disabling-dialog button[data-e2e-button="confirm"]' );
 
-			await page.click( 'div.auto-renew-disabling-dialog button[data-e2e-button="confirm"]' );
-
-			await page.click( 'button[data-e2e-button="skip"]' );
-		} catch {
-			// ...
-		}
+				await page.click( 'button[data-e2e-button="skip"]' );
+			},
+		);
 
 		// click on the remove purchase card
 		await page.click( 'css=button.remove-purchase__card' );
 
-		// there might be a non-primary domain dialog
-		try {
-			await page.await( 'css=div.non-primary-domain-dialog', {
+		// there might be a non-primary domain dialog for those sites bound to a free .blog domain, e.g. xxx.photo.blog
+		await asyncIf(
+			async () => page.waitForSelector( 'css=div.non-primary-domain-dialog', {
 				timeout: 1000,
-			} );
-			await page.click( 'css=div.dialog__action-buttons button[data-e2e-button="remove"]' );
-		} catch {
-			// ...
-		}
+			} ),
+			async () => {
+				page.click( 'css=div.dialog__action-buttons button[data-e2e-button="remove"]' );
+			}
+		);
 
-		await new Promise( res => setTimeout(res, 10000000 ));
+		// if it's a cancel purchase form.
+		await asyncIf(
+			async () => await page.waitForSelector( 'div.cancel-purchase-form__dialog', {
+				timeout: 1000,
+			} ),
+			// if a plan subscription cancellation survey is shown.
+			asyncIf(
+				async () => await page.check( 'css=input[name="anotherReasonOne"]', {
+					timeout: 3000,
+				} ),
+				async () => {
+					// fill out the survey.
+					await page.fill( 'css=input[name="anotherReasonOneInput"]', 'test' );
+					await page.check( 'css=input[name="anotherReasonTwo"]' );
+					await page.fill( 'css=input[name="anotherReasonTwoInput"]', 'test' );
+					await page.click( 'css=button[data-e2e-button="next"]' );
 
-		try {
-			try {
-				// see if it's a plan subscription first.
-				await page.waitForSelector( 'div.cancel-purchase-form__dialog', {
-					timeout: 1000,
-				} );
+					await page.click( 'css=button[data-e2e-button="remove"]' );
+				},
+				async () => {
+					// it's also possible that there is no survey, but the button is there e.g. a domain mapping
+					// in those cases, we can just click on the button of doom.
+					await page.click( 'css=button[data-e2e-button="remove"]' );
+				},
+			),
+		);
 
-				// survey page 1
-				await page.check( 'css=input[name="anotherReasonOne"]', {
-					timeout: 3000, } );
-				await page.fill( 'css=input[name="anotherReasonOneInput"]', 'test' );
-				await page.check( 'css=input[name="anotherReasonTwo"]' );
-				await page.fill( 'css=input[name="anotherReasonTwoInput"]', 'test' );
-				await page.click( 'css=button[data-e2e-button="next"]' );
-			} finally { // it's also possible that there is no survey, but the button is there e.g. a domain mapping
-				// say goodbye
+		// it can be a domain cancellation form.
+		await asyncIf(
+			async () => await page.waitForSelector( 'div.remove-domain-dialog__dialog', {
+				timeout: 1000,
+			} ),
+			async () => {
 				await page.click( 'css=button[data-e2e-button="remove"]' );
-			}
 
-			return {};
-		} catch {
-			// Nope.
-			console.log( 'A purchase cancellation form is not found. Try something else ...' );
-		}
+				const domain = await extractDomainStringfromDialog( page );
 
-		console.error( '----------------??????????????????????????' );
+				if ( ! domain ) {
+					console.error( 'Cannot find a domain string in the domain cancellation dialog. Aborting.' );
 
-		try {
-			// so it can be a domain ...
-			await page.waitForSelector( 'div.remove-domain-dialog__dialog', {
-				timeout: 1000,
-			} );
-			await page.click( 'css=button[data-e2e-button="remove"]' );
+					return {
+						abort: true,
+					};
+				}
 
-			const domain = await extractDomainStringfromDialog( page );
-
-			if ( ! domain ) {
-				console.error( 'Cannot find a domain string in the domain cancellation dialog. Aborting.' );
-
-				return {
-					abort: true,
-				};
-			}
-
-			await page.fill( 'css=input[name="domain"]', domain );
-			await page.check( 'css=input[name="agree"]' );
-			await page.click( 'css=button[data-e2e-button="remove"]' );
-
-			return {};
-		} catch {
-			// something else we didn't handle. Abort.
-			return {
-				abort: true,
-			};
-		}
+				await page.fill( 'css=input[name="domain"]', domain );
+				await page.check( 'css=input[name="agree"]' );
+				await page.click( 'css=button[data-e2e-button="remove"]' );
+			},
+		);
 
 		return {};
 	},
@@ -122,20 +114,16 @@ const removeAllPurchases = createAction(
 	async ( browser, context, page, extra ) => {
 		await page.goto( getRootUrlFromEnv( extra.config.env ) + '/me/purchases' );
 
-		try {
-			await page.waitForSelector( 'css=a[data-e2e-connected-site=true]:last-child', {
+		return asyncIf(
+			async () => page.waitForSelector( 'css=a[data-e2e-connected-site=true]:last-child', {
 				timeout: 3000,
-			});
+			}),
+			async () => {
+				await removePurchase.run( browser, context, page, extra );
 
-			await removePurchase.run( browser, context, page, extra );
-
-			return removeAllPurchases.run( browser, context, page, extra );
-		} catch {
-			// no more remaining purchase cards, so it should be all done.
-			return {};
-		}
-
-		return {};
+				return removeAllPurchases.run( browser, context, page, extra );
+			},
+		);
 	},
 	'/me/purchases'
 );

--- a/actions/remove-all-purchases.js
+++ b/actions/remove-all-purchases.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+const validator = require( 'validator' );
+
+/**
+ * Internal dependencies
+ */
+const { createAction } = require( '../lib/action.js' );
+const { getRootUrlFromEnv } = require( '../lib/misc.js' );
+
+const extractDomainStringfromDialog = async ( page ) => {
+	const candidateElems = await page.$$( 'css=.remove-domain-dialog__dialog p strong' );
+
+	for ( const candidateElem of candidateElems ) {
+		const innerText = await candidateElem.innerText();
+
+		if ( validator.isURL( innerText ) ) {
+			return innerText;
+		}
+	}
+
+	return null;
+};
+
+const removePurchase = createAction(
+	async ( browser, context, page, extra ) => {
+
+		// go into the 1st one. Yeah, it's weird that :last-child actually refers to the 1st one in Playwright somehow.
+		await page.click( 'css=a[data-e2e-connected-site=true]:last-child' );
+
+		// click on the remove purchase card
+		await page.click( 'css=button.remove-purchase__card' );
+
+		try {
+			// see if it's a plan subscription first.
+			await page.waitForSelector( 'div.cancel-purchase-form__dialog', {
+				timeout: 1000,
+			} );
+
+			// survey page 1
+			await page.check( 'css=input[name="anotherReasonOne"]' );
+			await page.fill( 'css=input[name="anotherReasonOneInput"]', 'test' );
+			await page.check( 'css=input[name="anotherReasonTwo"]' );
+			await page.fill( 'css=input[name="anotherReasonTwoInput"]', 'test' );
+			await page.click( 'css=button[data-e2e-button="next"]' );
+
+			// say goodbye
+			await page.click( 'css=button[data-e2e-button="remove"]' );
+
+			return {};
+		} catch {
+			// Nope.
+			console.log( 'A purchase cancellation form is not found. Try something else ...' );
+		}
+
+		try {
+			// so it can be a domain ...
+			await page.waitForSelector( 'div.remove-domain-dialog__dialog' );
+			await page.click( 'css=button[data-e2e-button="remove"]' );
+
+			const domain = await extractDomainStringfromDialog( page );
+
+			if ( ! domain ) {
+				console.error( 'Cannot find a domain string in the domain cancellation dialog. Aborting.' );
+
+				return {
+					abort: true,
+				};
+			}
+
+			await page.fill( 'css=input[name="domain"]', domain );
+			await page.check( 'css=input[name="agree"]' );
+			await page.click( 'css=button[data-e2e-button="remove"]' );
+
+			return {};
+		} catch {
+			// something else we didn't handle. Abort.
+			return {
+				abort: true,
+			};
+		}
+
+		return {};
+	},
+	'/me/purchases'
+);
+
+const removeAllPurchases = createAction(
+	async ( browser, context, page, extra ) => {
+		await page.goto( getRootUrlFromEnv( extra.config.env ) + '/me/purchases' );
+
+		const purchaseCard = await page.waitForSelector( 'css=a[data-e2e-connected-site=true]:last-child' );
+
+		if ( purchaseCard ) {
+			await removePurchase.run( browser, context, page, extra );
+
+			return removeAllPurchases.run( browser, context, page, extra );
+		}
+
+		return {};
+	},
+	'/me/purchases'
+);
+
+// remove all purchases from a logged-in account
+module.exports = removeAllPurchases;

--- a/actions/remove-all-purchases.js
+++ b/actions/remove-all-purchases.js
@@ -29,24 +29,52 @@ const removePurchase = createAction(
 		// go into the 1st one. Yeah, it's weird that :last-child actually refers to the 1st one in Playwright somehow.
 		await page.click( 'css=a[data-e2e-connected-site=true]:last-child' );
 
-		// click on the remove purchase card
-		await page.click( 'css=button.remove-purchase__card' );
-
+		// Toggle off auto-renewal if any
 		try {
-			// see if it's a plan subscription first.
-			await page.waitForSelector( 'div.cancel-purchase-form__dialog', {
+			await page.click( 'css=.components-form-toggle.is-checked input[type="checkbox"]', {
 				timeout: 1000,
 			} );
 
-			// survey page 1
-			await page.check( 'css=input[name="anotherReasonOne"]' );
-			await page.fill( 'css=input[name="anotherReasonOneInput"]', 'test' );
-			await page.check( 'css=input[name="anotherReasonTwo"]' );
-			await page.fill( 'css=input[name="anotherReasonTwoInput"]', 'test' );
-			await page.click( 'css=button[data-e2e-button="next"]' );
+			await page.click( 'div.auto-renew-disabling-dialog button[data-e2e-button="confirm"]' );
 
-			// say goodbye
-			await page.click( 'css=button[data-e2e-button="remove"]' );
+			await page.click( 'button[data-e2e-button="skip"]' );
+		} catch {
+			// ...
+		}
+
+		// click on the remove purchase card
+		await page.click( 'css=button.remove-purchase__card' );
+
+		// there might be a non-primary domain dialog
+		try {
+			await page.await( 'css=div.non-primary-domain-dialog', {
+				timeout: 1000,
+			} );
+			await page.click( 'css=div.dialog__action-buttons button[data-e2e-button="remove"]' );
+		} catch {
+			// ...
+		}
+
+		await new Promise( res => setTimeout(res, 10000000 ));
+
+		try {
+			try {
+				// see if it's a plan subscription first.
+				await page.waitForSelector( 'div.cancel-purchase-form__dialog', {
+					timeout: 1000,
+				} );
+
+				// survey page 1
+				await page.check( 'css=input[name="anotherReasonOne"]', {
+					timeout: 3000, } );
+				await page.fill( 'css=input[name="anotherReasonOneInput"]', 'test' );
+				await page.check( 'css=input[name="anotherReasonTwo"]' );
+				await page.fill( 'css=input[name="anotherReasonTwoInput"]', 'test' );
+				await page.click( 'css=button[data-e2e-button="next"]' );
+			} finally { // it's also possible that there is no survey, but the button is there e.g. a domain mapping
+				// say goodbye
+				await page.click( 'css=button[data-e2e-button="remove"]' );
+			}
 
 			return {};
 		} catch {
@@ -54,9 +82,13 @@ const removePurchase = createAction(
 			console.log( 'A purchase cancellation form is not found. Try something else ...' );
 		}
 
+		console.error( '----------------??????????????????????????' );
+
 		try {
 			// so it can be a domain ...
-			await page.waitForSelector( 'div.remove-domain-dialog__dialog' );
+			await page.waitForSelector( 'div.remove-domain-dialog__dialog', {
+				timeout: 1000,
+			} );
 			await page.click( 'css=button[data-e2e-button="remove"]' );
 
 			const domain = await extractDomainStringfromDialog( page );
@@ -90,12 +122,17 @@ const removeAllPurchases = createAction(
 	async ( browser, context, page, extra ) => {
 		await page.goto( getRootUrlFromEnv( extra.config.env ) + '/me/purchases' );
 
-		const purchaseCard = await page.waitForSelector( 'css=a[data-e2e-connected-site=true]:last-child' );
+		try {
+			await page.waitForSelector( 'css=a[data-e2e-connected-site=true]:last-child', {
+				timeout: 3000,
+			});
 
-		if ( purchaseCard ) {
 			await removePurchase.run( browser, context, page, extra );
 
 			return removeAllPurchases.run( browser, context, page, extra );
+		} catch {
+			// no more remaining purchase cards, so it should be all done.
+			return {};
 		}
 
 		return {};

--- a/actions/remove-purchase.js
+++ b/actions/remove-purchase.js
@@ -1,9 +1,0 @@
-const { createAction } = require( '../lib/action.js' );
-
-// remove a purchase from a logged-in account
-module.exports = createAction(
-	async ( browser, context, page, extra ) => {
-		return {};
-	},
-	'/me/purchases'
-);

--- a/actions/remove-purchase.js
+++ b/actions/remove-purchase.js
@@ -1,0 +1,9 @@
+const { createAction } = require( '../lib/action.js' );
+
+// remove a purchase from a logged-in account
+module.exports = createAction(
+	async ( browser, context, page, extra ) => {
+		return {};
+	},
+	'/me/purchases'
+);

--- a/lib/action.js
+++ b/lib/action.js
@@ -12,7 +12,54 @@ createPreparation = ( run ) => {
 	};
 };
 
+const readActionFile = ( actionFile ) => {
+	// FIXME: can we make this smarter without the relative path?
+	const actionDir = '../actions/';
+	const localActionDir = '../local-actions/';
+
+	try {
+		// look into the local actions dir.
+		try {
+			const actionFunc = require( localActionDir + actionFile )
+
+			return actionFunc;
+		} catch ( error ) {
+			if ( error.code != 'MODULE_NOT_FOUND' ) {
+				throw error;
+			}
+		}
+
+		// now, look into the standard one.
+		const actionFunc = require( actionDir + actionFile );
+
+		return actionFunc;
+
+	} catch ( error ) {
+		console.error( 'A fatal error has occured when reading the action: ', actionFile, error, error.code );
+
+		return false;
+	}
+};
+
+const readActionFiles = ( actionFiles ) => {
+	const actions = [];
+
+	for ( const actionFile of actionFiles ) {
+		const result = readActionFile( actionFile );
+
+		if ( ! result ) {
+			return process.exit( -1 );
+		}
+
+		actions.push( result );
+	}
+
+	return actions;
+};
+
 module.exports = {
 	createAction,
 	createPreparation,
+	readActionFile,
+	readActionFiles,
 };

--- a/lib/action.js
+++ b/lib/action.js
@@ -57,7 +57,21 @@ const readActionFiles = ( actionFiles ) => {
 	return actions;
 };
 
+const asyncIf = async ( conditionFunc, ifFunc, elseFunc ) => {
+	try {
+		await conditionFunc();
+
+		return await ifFunc();
+
+	} catch {
+		if ( elseFunc ) {
+			return await elseFunc();
+		}
+	}
+};
+
 module.exports = {
+	asyncIf,
 	createAction,
 	createPreparation,
 	readActionFile,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+
+// priority: extendedPaths -> primaryDir. e.g. `local-configs` should be preferred over `configs`.
+const resolvePath = ( primaryDir, extendedPaths, targetFileName ) => {
+	const dirs = [
+		...extendedPaths,
+		primaryDir,
+	];
+
+	for( const dir of dirs ) {
+		const candidatePath = dir + targetFileName;
+
+		if ( fs.existsSync( candidatePath ) ) {
+			return candidatePath;
+		}
+	}
+
+	return null;
+};
+
+const readConfigFile = ( configFile ) => {
+	try {
+		const content = fs.readFileSync( configFile );
+		const configObj = JSON.parse( content );
+		return configObj;
+	} catch( error ) {
+		// FIXME: inproper place to print a log
+		console.error( 'An error has occureed during reading the config file: ' + configFile, error );
+
+		return false;
+	}
+};
+
+// TBD: maybe add a restricted config schema?
+const mergeConfig = ( current, next ) => {
+	const merged = { ... current };
+
+	for ( const key in next ) {
+		const curValue = current[ key ];
+		const nextValue = next[ key ];
+
+		// this is so that array-valued properties like localStorage and cookies can be accumulated through multiple configs.
+		if ( Array.isArray( curValue ) && Array.isArray( nextValue ) ) {
+			merged[ key ] = curValue.concat( nextValue );
+		} else {
+			merged[ key ] = nextValue;
+		}
+	}
+
+	return merged;
+};
+
+const readConfigFiles = ( configFiles ) => {
+	const configDir = './configs/';
+	const localConfigDir = './local-configs/';
+
+	let unionConfig = {};
+
+	for ( const configFile of configFiles ) {
+		const resolvedPath = resolvePath( configDir, [ localConfigDir ], configFile + '.json' );
+
+		if ( ! resolvedPath ) {
+			continue;
+		}
+
+		const result = readConfigFile( resolvedPath );
+
+		if ( ! result ) {
+			return false;
+		}
+
+		unionConfig = mergeConfig( unionConfig, result );
+	}
+
+	return unionConfig;
+};
+
+module.exports = {
+	readConfigFile,
+	readConfigFiles,
+	mergeConfig,
+};

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,80 +1,3 @@
-const fs = require( 'fs' );
-
-// priority: extendedPaths -> primaryDir. e.g. `local-configs` should be preferred over `configs`.
-const resolvePath = ( primaryDir, extendedPaths, targetFileName ) => {
-	const dirs = [
-		...extendedPaths,
-		primaryDir,
-	];
-
-	for( const dir of dirs ) {
-		const candidatePath = dir + targetFileName;
-
-		if ( fs.existsSync( candidatePath ) ) {
-			return candidatePath;
-		}
-	}
-
-	return null;
-};
-
-const readConfigFile = ( configFile ) => {
-	try {
-		const content = fs.readFileSync( configFile );
-		const configObj = JSON.parse( content );
-		return configObj;
-	} catch( error ) {
-		// FIXME: inproper place to print a log
-		console.error( 'An error has occureed during reading the config file: ' + configFile, error );
-
-		return false;
-	}
-};
-
-// TBD: maybe add a restricted config schema?
-const mergeConfig = ( current, next ) => {
-	const merged = { ... current };
-
-	for ( const key in next ) {
-		const curValue = current[ key ];
-		const nextValue = next[ key ];
-
-		// this is so that array-valued properties like localStorage and cookies can be accumulated through multiple configs.
-		if ( Array.isArray( curValue ) && Array.isArray( nextValue ) ) {
-			merged[ key ] = curValue.concat( nextValue );
-		} else {
-			merged[ key ] = nextValue;
-		}
-	}
-
-	return merged;
-};
-
-const readConfigFiles = ( configFiles ) => {
-	const configDir = './configs/';
-	const localConfigDir = './local-configs/';
-
-	let unionConfig = {};
-
-	for ( const configFile of configFiles ) {
-		const resolvedPath = resolvePath( configDir, [ localConfigDir ], configFile + '.json' );
-
-		if ( ! resolvedPath ) {
-			continue;
-		}
-
-		const result = readConfigFile( resolvedPath );
-
-		if ( ! result ) {
-			return false;
-		}
-
-		unionConfig = mergeConfig( unionConfig, result );
-	}
-
-	return unionConfig;
-};
-
 const initialize = async ( config ) => {
 	const {
 		browser: browserSlug,
@@ -112,7 +35,7 @@ const initialize = async ( config ) => {
 	};
 };
 
-const configLocalStorage = async ( page, entries ) => {
+const setLocalStorage = async ( page, entries ) => {
 	// TODO: better error handling
 	for ( const entry of entries ) {
 		await page.evaluate( ( [ key, value ] ) => {
@@ -122,8 +45,6 @@ const configLocalStorage = async ( page, entries ) => {
 };
 
 module.exports = {
-	configLocalStorage,
-	readConfigFiles,
+	setLocalStorage,
 	initialize,
-	mergeConfig,
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -75,38 +75,6 @@ const readConfigFiles = ( configFiles ) => {
 	return unionConfig;
 };
 
-const readActionFile = ( actionFile ) => {
-	try {
-		const actionFunc = require( actionFile );
-
-		return actionFunc;
-	} catch ( error ) {
-		return false;
-	}
-};
-
-const readActionFiles = ( actionFiles ) => {
-	const actions = [];
-
-	// FIXME: can we make this smarter without the relative path?
-	const actionDir = '../actions/';
-	const localActionDir = '../local-actions/';
-
-	for ( const actionFile of actionFiles ) {
-		const result = readActionFile( localActionDir + actionFile ) ||
-						readActionFile( actionDir + actionFile );
-
-		if ( ! result ) {
-			console.error( 'A fatal error has occured when reading the action: ', actionFile );
-			return process.exit( -1 );
-		}
-
-		actions.push( result );
-	}
-
-	return actions;
-};
-
 const initialize = async ( config ) => {
 	const {
 		browser: browserSlug,
@@ -156,7 +124,6 @@ const configLocalStorage = async ( page, entries ) => {
 module.exports = {
 	configLocalStorage,
 	readConfigFiles,
-	readActionFiles,
 	initialize,
 	mergeConfig,
 };

--- a/main.js
+++ b/main.js
@@ -7,11 +7,10 @@ const yargs = require( 'yargs' );
  * Internal dependencies
  */
 const {
-	configLocalStorage,
-	readConfigFiles,
+	setLocalStorage,
 	initialize,
-	mergeConfig,
 } = require( './lib/init.js' );
+const { readConfigFiles, mergeConfig } = require( './lib/config.js' );
 const { readActionFiles } = require( './lib/action.js' );
 const { getRootUrlFromEnv, parseNonSpaceSeparatedList } = require( './lib/misc.js' );
 
@@ -152,7 +151,7 @@ const main = async () => {
 			if ( firstNavigation ) {
 				await page.goto( getRootUrlFromEnv( unionConfig.env ) + action.initialPath );
 				if ( unionConfig.localStorage ) {
-					await configLocalStorage( page, unionConfig.localStorage );
+					await setLocalStorage( page, unionConfig.localStorage );
 				}
 
 				firstNavigation = false;

--- a/main.js
+++ b/main.js
@@ -9,10 +9,10 @@ const yargs = require( 'yargs' );
 const {
 	configLocalStorage,
 	readConfigFiles,
-	readActionFiles,
 	initialize,
 	mergeConfig,
 } = require( './lib/init.js' );
+const { readActionFiles } = require( './lib/action.js' );
 const { getRootUrlFromEnv, parseNonSpaceSeparatedList } = require( './lib/misc.js' );
 
 // TODO: this shouldn't be too hard to generalized to enable complete overriding of config flags through commandline params. I should consider to implement a config schema.

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "main.js",
   "author": "James Tien <james.tien@automattic.com>",
   "license": "MIT",
-	"scripts": {
-		"start": "DEBUG=pw:api node main.js"
-	},
+  "scripts": {
+    "start": "DEBUG=pw:api node main.js"
+  },
   "devDependencies": {
     "playwright": "^1.8.1",
+    "validator": "^13.6.0",
     "yargs": "^16.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,11 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+validator@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
+  integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"


### PR DESCRIPTION
## Summary

This PR enhances the `close-account` action to handle a lot more cases to make my life easier, together with a fair amount of refactoring to make that possible. There are still cases that it hasn't handled or is impossible to handle, but it's already a good progress:

* There is currently a bug in Calypso that a support session doesn't have the remove button, so it's not possible to remove.
* An Atomic site needs HE intervention to close, so it's also not possible to close by browser automation.
* An account setup by the magic link, 2FA, social single-sign-on, is too complicated to handle for now.