### PR TITLE
Add a new config prop: currency

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -23,7 +23,10 @@ const initialize = async ( config ) => {
 		locale,
 	} );
 
-	await context.addCookies( cookies );
+	await context.addCookies( [
+		...cookies,
+		...convertCookiesProps( config ),
+	] );
 
 	// config the page instance
 	const page = await context.newPage();
@@ -33,6 +36,21 @@ const initialize = async ( config ) => {
 		context,
 		page,
 	};
+};
+
+const convertCookiesProps = ( { currency } ) => {
+	const cookies = [];
+
+	if ( currency ) {
+		cookies.push( {
+			name: 'landingpage_currency',
+			value: currency,
+			domain: '.wordpress.com',
+			path: '/'
+		} );
+	}
+
+	return cookies;
 };
 
 const setLocalStorage = async ( page, entries ) => {

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ const parseOverrides = ( argv ) => {
 	const eligibleParams = [
 		'browser',
 		'cookies',
+		'currency',
 		'env',
 		'path',
 		'username',
@@ -58,6 +59,9 @@ const parseCommandLine = () => {
 			type: 'string',
 		} )
 		.option( 'cookies', {
+			type: 'string',
+		} )
+		.option( 'currency', {
 			type: 'string',
 		} )
 		.option( 'env', {


### PR DESCRIPTION
This is the start of adding dotcom specific handy configuration from the general ones. The `currency` flag here simply adds `landingpage_currency` cookie for you in a less daunting way.