### PR TITLE
Only navigate to the initial path of an action when it hasn't been done yet.

### DIFF
--- a/actions/pick-business-plan.js
+++ b/actions/pick-business-plan.js
@@ -8,5 +8,5 @@ module.exports = createAction(
 
 		return {};
 	},
-	'/plans/'
+	'/plans'
 );

--- a/actions/pick-personal-plan.js
+++ b/actions/pick-personal-plan.js
@@ -8,5 +8,5 @@ module.exports = createAction(
 
 		return {};
 	},
-	'/plans/'
+	'/plans'
 );

--- a/actions/pick-premium-plan.js
+++ b/actions/pick-premium-plan.js
@@ -8,5 +8,5 @@ module.exports = createAction(
 
 		return {};
 	},
-	'/plans/'
+	'/plans'
 );

--- a/main.js
+++ b/main.js
@@ -151,7 +151,9 @@ const main = async () => {
 			continue;
 		}
 
-		if ( action.initialPath != null ) {
+		const { initialPath } = action;
+
+		if ( initialPath != null ) {
 			if ( firstNavigation ) {
 				await page.goto( getRootUrlFromEnv( unionConfig.env ) + action.initialPath );
 				if ( unionConfig.localStorage ) {
@@ -160,7 +162,15 @@ const main = async () => {
 
 				firstNavigation = false;
 			} else {
-				await page.waitForNavigation( action.initialPath );
+				const initialPathRegex = new RegExp( action.initialPath, 'i' );
+				const currentUrl = new URL( page.url() );
+
+				// using a regex match here because I don't want it to be too strict.
+				if ( ! initialPathRegex.test( currentUrl ) ) {
+					await page.waitForNavigation( {
+						url: initialPathRegex,
+					} );
+				}
 			}
 		}
 		// finish up all the queued preparation


### PR DESCRIPTION
On a SPA, chances are that the navigation has already been done even
before `waitForNavigation()` call is made, e.g. the latest calypso
reskinned sign-up. Thus, we should check that before calling
`waitForNavigation()`, or we'd simply stuck.