### PR TITLE
Update the pick-free-plan action to adapt the newly introduced plan grid.

### DIFF
--- a/actions/pick-free-plan.js
+++ b/actions/pick-free-plan.js
@@ -3,7 +3,8 @@ const { createAction } = require( '../lib/action' );
 // Pick the Free plan at the /plans step
 module.exports = createAction(
 	async ( browser, context, page ) => {
-		await page.click( 'css=#step-header >> css=button[type="button"]' );
+		// Terrible, but it is what it is before a more semantic structure is introduced.
+		await page.click( 'text=Start with Free' );
 
 		return {};
 	},


### PR DESCRIPTION
I don't want to use `text=` selector, really. However, the current semantic structure isn't quite there so ...